### PR TITLE
feat: dynamically fetch supported release branches

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -5,6 +5,5 @@ workflow "Check Unreleased Commits" {
 
 action "Check unreleased commits" {
   uses = "./"
-  args = "6-0-x,5-0-x,4-2-x,3-1-x"
   secrets = ["GITHUB_TOKEN", "SLACK_BOT_TOKEN"]
 }

--- a/entrypoint.js
+++ b/entrypoint.js
@@ -1,13 +1,13 @@
 const { Toolkit } = require('actions-toolkit')
 const { WebClient } = require('@slack/web-api')
 
-const { fetchUnreleasedCommits, linkifyPRs } = require('./utils')
+const { fetchUnreleasedCommits, linkifyPRs, getSupportedBranches } = require('./utils')
 
 const SLACK_BOT_TOKEN = process.env.SLACK_BOT_TOKEN
 const slackWebClient =  new WebClient(SLACK_BOT_TOKEN)
 
 Toolkit.run(async tools => {
-  const branches = tools.arguments._[0].split(',') || 'master'
+  const branches = await getSupportedBranches()
   for (const branch of branches) {
     tools.log.info(`Auditing branch ${branch}`)
 

--- a/utils.js
+++ b/utils.js
@@ -4,6 +4,7 @@ const GH_API_PREFIX = 'https://api.github.com'
 const ORGANIZATION_NAME = 'electron'
 const REPO_NAME = 'electron'
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN
+const NUM_SUPPORTED_VERSIONS = 4
 
 async function getAll(urlEndpoint) {
   const objects = []
@@ -68,8 +69,8 @@ async function getSupportedBranches() {
   }).map(b => b.name)
 
   const filtered = {}
-  branches.forEach(branch => filtered[branch.charAt(0)] = branch)
-  return Object.values(filtered).slice(-4)
+  branches.sort().forEach(branch => filtered[branch.charAt(0)] = branch)
+  return Object.values(filtered).slice(-NUM_SUPPORTED_VERSIONS)
 }
 
 module.exports = {

--- a/utils.js
+++ b/utils.js
@@ -58,7 +58,22 @@ async function fetchUnreleasedCommits(branch) {
   return unreleased
 }
 
+async function getSupportedBranches() {
+  const branchEndpoint = `${GH_API_PREFIX}/repos/electron/electron/branches`
+  const resp = await fetch(branchEndpoint)
+
+  let branches = await resp.json()
+  branches = branches.filter(branch => {
+    return branch.protected && branch.name.match(/[0-9]-[0-9]-x/)
+  }).map(b => b.name)
+
+  const filtered = {}
+  branches.forEach(branch => filtered[branch.charAt(0)] = branch)
+  return Object.values(filtered).slice(-4)
+}
+
 module.exports = {
+  getSupportedBranches,
   linkifyPRs,
   fetchUnreleasedCommits
 }


### PR DESCRIPTION
This reduces maintenance burden on this repo by adding a function to dynamically fetch supported release lines for the weekly cron job, so that we don't have to manually update this when new lines are cut.

cc @electron/wg-releases 