### PR TITLE
fix: use '@releases-wg' for workgroup mentions

### DIFF
--- a/entrypoint.js
+++ b/entrypoint.js
@@ -26,7 +26,7 @@ Toolkit.run(async tools => {
       response = `Unreleased commits in *${branch}* (automatic audit):\n${formattedCommits}`
       if (commits.length >= 10) {
         tools.log.info(`Reached ${commits.length} commits on ${branch}, time to release.`)
-        response += `\n <@wg-releases>, there are a lot of unreleased commits on \`${branch}\`! Time for a release?`
+        response += `\n <@releases-wg>, there are a lot of unreleased commits on \`${branch}\`! Time for a release?`
       }
     }
 

--- a/server.js
+++ b/server.js
@@ -35,7 +35,7 @@ app.post('/audit', async (req, res) => {
 
       response = `Unreleased commits in *${branch}* (from <@${req.body.user_id}>):\n${formattedCommits}`
       if (commits.length >= 10) {
-        response += `\n <@wg-releases>, there are a lot of unreleased commits on \`${branch}\`! Time for a release?`
+        response += `\n <@releases-wg>, there are a lot of unreleased commits on \`${branch}\`! Time for a release?`
       }
     }
   


### PR DESCRIPTION
Fix the @ name used to get the Releases WG's attention.