### PR TITLE
feat: manual status query for all supported branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,9 @@ Example:
 ```sh
 /check-unreleased 5-0-x
 ```
+
+To manually query the status of all [currently supported](https://electronjs.org/docs/tutorial/support) Electron release branches:
+
+```sh
+/check-unreleases all
+```


### PR DESCRIPTION
Allow for users to manually query for the status of all currently supported release branches instead of needing to query branch-by-branch.

cc @ckerr @MarshallOfSound 