### PR TITLE
feat: allow users to query for unmerged prs

### DIFF
--- a/utils/commits-helpers.js
+++ b/utils/commits-helpers.js
@@ -1,0 +1,46 @@
+const fetch = require('node-fetch')
+
+const { GITHUB_TOKEN } = require('../constants')
+
+// Formulate a list of all commits based on a certain url endpoint
+// for a release tag on Electron
+async function getAll(urlEndpoint) {
+  const objects = []
+  for await (const obj of getAllGenerator(urlEndpoint)) objects.push(obj)
+  return objects
+}
+
+// Generate and iterate through the JSON blob representing commits
+async function* getAllGenerator(urlEndpoint) {
+  let next = urlEndpoint
+  while (true) {
+    const resp = await fetch(next, {
+      headers: { Authorization: `token ${GITHUB_TOKEN}` }
+    })
+
+    if (!resp.ok) {
+      if (resp.headers.get('x-ratelimit-remaining') === '0') {
+        const resetTime = Math.round(resp.headers.get('x-ratelimit-reset') - Date.now() / 1000)
+        throw new Error(`Ratelimited. Resets in ${resetTime} seconds.`)
+      }
+      throw new Error(`${resp.status} ${resp.statusText}`)
+    }
+
+    const json = await resp.json()
+    yield* json
+
+    if (!resp.headers.get('link')) break
+    const next_link = resp.headers.get('link')
+      .split(/,/)
+      .map(x => x.split(/;/))
+      .find(x => x[1].includes('next'))
+
+    if (!next_link) break
+    next = next_link[0].trim().slice(1, -1)
+  }
+}
+
+module.exports = {
+  getAll,
+  getAllGenerator
+}

--- a/utils/commits-helpers.js
+++ b/utils/commits-helpers.js
@@ -18,6 +18,8 @@ async function* getAllGenerator(urlEndpoint) {
       headers: { Authorization: `token ${GITHUB_TOKEN}` }
     })
 
+    console.log(resp)
+
     if (!resp.ok) {
       if (resp.headers.get('x-ratelimit-remaining') === '0') {
         const resetTime = Math.round(resp.headers.get('x-ratelimit-reset') - Date.now() / 1000)

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -38,8 +38,6 @@ async function getSupportedBranches() {
   return Object.values(filtered).slice(-NUM_SUPPORTED_VERSIONS)
 }
 
-/* SLACK HELPERS */
-
 // Post a message to a Slack workspace
 const postToSlack = (data, postUrl) => {
   const r = https.request({
@@ -52,18 +50,9 @@ const postToSlack = (data, postUrl) => {
   r.end(JSON.stringify(data))
 }
 
-// Post invalid branch message to Slack
-const postInvalidBranch = (req) => {
-  return postToSlack({
-    response_type: 'ephemeral',
-    text: 'Branch name not valid. Try again?'
-  }, req.body.response_url)
-}
-
 module.exports = {
   releaseIsDraft,
   getSupportedBranches,
   linkifyPRs,
-  postToSlack,
-  postInvalidBranch
+  postToSlack
 }

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -38,6 +38,8 @@ async function getSupportedBranches() {
   return Object.values(filtered).slice(-NUM_SUPPORTED_VERSIONS)
 }
 
+/* SLACK HELPERS */
+
 // Post a message to a Slack workspace
 const postToSlack = (data, postUrl) => {
   const r = https.request({
@@ -50,9 +52,18 @@ const postToSlack = (data, postUrl) => {
   r.end(JSON.stringify(data))
 }
 
+// Post invalid branch message to Slack
+const postInvalidBranch = (req) => {
+  return postToSlack({
+    response_type: 'ephemeral',
+    text: 'Branch name not valid. Try again?'
+  }, req.body.response_url)
+}
+
 module.exports = {
   releaseIsDraft,
   getSupportedBranches,
   linkifyPRs,
-  postToSlack
+  postToSlack,
+  postInvalidBranch
 }

--- a/utils/unmerged-commits.js
+++ b/utils/unmerged-commits.js
@@ -1,0 +1,41 @@
+const { getAllGenerator } = require('./commits-helpers')
+const { linkifyPRs } = require('./helpers')
+
+const {
+  ORGANIZATION_NAME,
+  REPO_NAME,
+  GH_API_PREFIX,
+  SLACK_USER
+} = require('../constants')
+
+// Fetch all PRs targeting a specified release line branch that have NOT been merged
+async function fetchUnmergedPRs(branch) {
+  const url = `${GH_API_PREFIX}/repos/${ORGANIZATION_NAME}/${REPO_NAME}/pulls?base=${branch}`
+  const unmerged = []
+  for await (const commit of getAllGenerator(url)) {
+    unmerged.push(commit)
+  }
+  return unmerged
+}
+
+// Build the text blob that will be posted to Slack
+function buildUnmergedPRsMessage(branch, prs, initiatedBy) {
+  if (!prs || prs.length === 0) return `*No unmerged PRs for ${branch}*`
+
+  const formattedPRs = prs.map(c => {
+    const prLink = linkifyPRs(c.title.split(/[\r\n]/, 1)[0])
+    // TODO
+    // return `- \`<${c.html_url}|${c.sha.slice(0, 8)}>\` ${prLink}`
+  }).join('\n')
+
+  let response = `Unreleased pull requests targeting *${branch}* (from ${initiatedBy}):\n${formattedPRs}`
+  if (prs.length !== 0) {
+    response += `\n <@${SLACK_USER}>, there are unmerged PRs targeting \`${branch}\`! Don't release just yet!`
+  }
+  return response
+}
+
+module.exports = {
+  buildUnmergedPRsMessage,
+  fetchUnmergedPRs
+}

--- a/utils/unmerged-commits.js
+++ b/utils/unmerged-commits.js
@@ -27,7 +27,7 @@ function buildUnmergedPRsMessage(branch, prs, initiatedBy) {
 
   let response = `Unreleased pull requests targeting *${branch}* (from ${initiatedBy}):\n${formattedPRs}`
   if (prs.length !== 0) {
-    response += `\n <@${SLACK_USER}>, there are unmerged PRs targeting \`${branch}\`! Don't release just yet!`
+    response += `\n <@${SLACK_USER}>, there are unmerged PRs targeting \`${branch}\`! Are you sure you want to release?`
   }
   return response
 }

--- a/utils/unmerged-commits.js
+++ b/utils/unmerged-commits.js
@@ -1,5 +1,4 @@
 const { getAllGenerator } = require('./commits-helpers')
-const { linkifyPRs } = require('./helpers')
 
 const {
   ORGANIZATION_NAME,
@@ -23,9 +22,7 @@ function buildUnmergedPRsMessage(branch, prs, initiatedBy) {
   if (!prs || prs.length === 0) return `*No unmerged PRs for ${branch}*`
 
   const formattedPRs = prs.map(c => {
-    const prLink = linkifyPRs(c.title.split(/[\r\n]/, 1)[0])
-    // TODO
-    // return `- \`<${c.html_url}|${c.sha.slice(0, 8)}>\` ${prLink}`
+    return `- ${c.title.split(/[\r\n]/, 1)[0]} (<${c.url}|#${c.number}>)`
   }).join('\n')
 
   let response = `Unreleased pull requests targeting *${branch}* (from ${initiatedBy}):\n${formattedPRs}`


### PR DESCRIPTION
This allows for users to query for the number of unmerged pull requests targeting a specified release branch, so that we can properly assess that we've merged all outstanding backports before we begin a release.

cc @ckerr @MarshallOfSound 