### PR TITLE
feat: enable audit of needs-manual PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 This repository allows users to query information relating to release branches on [`electron/electron`](https://github.com/electron/electron).
 
-There are two potential actions possible:
+There are three potential actions possible:
 1. Reporting commits unreleased for a specific release branch.
 2. Reporting pull requests targeting a specific release branch that have not yet been merged.
+3. Reporting pull requests which need to be manually backported to a particular release line.
 
 An unreleased commit audit is triggered automatically via cron job on Monday mornings at 9AM PST for all supported release branches of Electron.
 
@@ -44,4 +45,20 @@ Example:
 
 ```sh
 /check-unmerged 5-0-x
+```
+
+### Check Needs Manual
+
+An audit of pull requests needing manual backport to a particular release line  can be triggered via Slack using the following:
+
+```sh
+/check-needs-manual <branch-name>
+```
+
+where `branch-name` matches the name of a release line branch of the Electron repository.
+
+Example:
+
+```sh
+/check-needs-manual 5-0-x
 ```

--- a/utils/needs-manual-prs.js
+++ b/utils/needs-manual-prs.js
@@ -1,0 +1,41 @@
+const fetch = require('node-fetch')
+const { ORGANIZATION_NAME, REPO_NAME } = require('../constants')
+
+// Fetch all PRs targeting 'master' that have a 'needs-manual/<branch>' label on them
+async function fetchNeedsManualPRs(branch) {
+  const baseUrl = `https://api.github.com/search/issues?`
+  
+  // Construct queryString components
+  const repo = `repo:${ORGANIZATION_NAME}/${REPO_NAME}`
+  const type = `type:pr`
+  const state = `state:closed`
+  const label = `label:"needs-manual-bp/${branch}"`
+  
+  // Assemble final endpoint
+  const url = baseUrl + `q=${type}+${repo}+${state}+${label}`
+
+  const resp = await fetch(url)
+  const prs = (await resp.json()).items
+
+  return prs
+}
+
+// Build the text blob that will be posted to Slack
+function buildNeedsManualPRsMessage(branch, prs, initiatedBy) {
+  if (!prs || prs.length === 0) return `*No PRs needing manual backport to ${branch}*`
+
+  const formattedPRs = prs.map(c => {
+    return `- ${c.title.split(/[\r\n]/, 1)[0]} (<${c.html_url}|#${c.number}>)`
+  }).join('\n')
+
+  let response = `PRs needing manual backport to *${branch}* (from ${initiatedBy}):\n${formattedPRs}`
+  if (prs.length !== 0) {
+    response += `\n *There are PRs needing manual backport to \`${branch}\`! Are you sure you want to release?*`
+  }
+  return response
+}
+
+module.exports = {
+  buildNeedsManualPRsMessage,
+  fetchNeedsManualPRs
+}

--- a/utils/unmerged-prs.js
+++ b/utils/unmerged-prs.js
@@ -10,8 +10,8 @@ const {
 async function fetchUnmergedPRs(branch) {
   const url = `${GH_API_PREFIX}/repos/${ORGANIZATION_NAME}/${REPO_NAME}/pulls?base=${branch}`
   const unmerged = []
-  for await (const commit of getAllGenerator(url)) {
-    unmerged.push(commit)
+  for await (const pr of getAllGenerator(url)) {
+    unmerged.push(pr)
   }
   return unmerged
 }


### PR DESCRIPTION
Closes https://github.com/electron/unreleased/issues/12.

This PR will allow members of the ElectronHQ slack workspace to run:

```sh
/check-needs-manual 5-0-x
```

to check for pull requests which have been merged to master and labeled 
with `target/BRANCH_NAME` that trop failed for and which still need manual backports.

cc @jkleinsc @ckerr 