### PR TITLE
refactor: message building for cleaner output

### DIFF
--- a/server.js
+++ b/server.js
@@ -188,11 +188,15 @@ app.post('/audit-pre-release', async (req, res) => {
     } else {
       message = `Pre-release audit for *${branch}* (from ${initiatedBy})\n`
       
-      message += `PRs needing manual backport to *${branch}*:\n`
-      message += `${buildNeedsManualPRsMessage(branch, needsManualPRs)}\n`
-      
-      message += `Unmerged pull requests targeting *${branch}*:\n`
-      message += `${buildUnmergedPRsMessage(branch, unmergedPRs, initiatedBy)}\n`
+      if (needsManualPRs.length !== 0) {
+        message += `PRs needing manual backport to *${branch}*:\n`
+        message += `${buildNeedsManualPRsMessage(branch, needsManualPRs)}\n`
+      }
+
+      if (unmergedPRs.length !== 0) {
+        message += `Unmerged pull requests targeting *${branch}*:\n`
+        message += `${buildUnmergedPRsMessage(branch, unmergedPRs)}\n`
+      }
     }
 
     postToSlack({

--- a/server.js
+++ b/server.js
@@ -32,9 +32,17 @@ app.post('/unmerged', async (req, res) => {
     const prs = await fetchUnmergedPRs(branch)
     console.log(`Found ${prs.length} unmerged PRs targeting ${branch}`)
 
+    let message
+    if (!prs || prs.length === 0) {
+      message = `*No PRs needing manual backport to ${branch}*`
+    } else {
+      message = `Unmerged pull requests targeting *${branch}* (from ${initiatedBy}):\n`
+      message += buildUnmergedPRsMessage(branch, prs)
+    }
+  
     postToSlack({
       response_type: 'in_channel',
-      text: buildUnmergedPRsMessage(branch, prs, initiatedBy)
+      text: message
     }, req.body.response_url)
 
     return res.status(200).end()
@@ -67,9 +75,17 @@ app.post('/needs-manual', async (req, res) => {
     const prs = await fetchNeedsManualPRs(branch, author)
     console.log(`Found ${prs.length} prs on ${branch}`)
 
+    let message
+    if (!prs || prs.length === 0) {
+      message = `*No PRs needing manual backport to ${branch}*`
+    } else {
+      message = `PRs needing manual backport to *${branch}* (from ${initiatedBy}):\n`
+      message += buildNeedsManualPRsMessage(branch, prs)
+    }
+
     postToSlack({
       response_type: 'in_channel',
-      text: buildNeedsManualPRsMessage(branch, prs, initiatedBy)
+      text: message
     }, req.body.response_url)
 
     return res.status(200).end()
@@ -166,13 +182,22 @@ app.post('/audit-pre-release', async (req, res) => {
     const unmergedPRs = await fetchUnmergedPRs(branch)
     console.log(`Found ${unmergedPRs.length} unmerged PRs targeting ${branch}`)
 
-    const unmergedMessage = buildUnmergedPRsMessage(branch, unmergedPRs, initiatedBy)
-    const needsManualMessage = buildNeedsManualPRsMessage(branch, needsManualPRs, initiatedBy)
-    const fullMessage = `${unmergedMessage}\n${needsManualMessage}`
+    let message
+    if ((needsManualPRs.length + unmergedPRs.length) === 0) {
+      message = `No PRs unmerged or needing manual backport for ${branch}`
+    } else {
+      message = `Pre-release audit for *${branch}* (from ${initiatedBy})\n`
+      
+      message += `PRs needing manual backport to *${branch}*:\n`
+      message += `${buildNeedsManualPRsMessage(branch, needsManualPRs)}\n`
+      
+      message += `Unmerged pull requests targeting *${branch}*:\n`
+      message += `${buildUnmergedPRsMessage(branch, unmergedPRs, initiatedBy)}\n`
+    }
 
     postToSlack({
       response_type: 'in_channel',
-      text: fullMessage
+      text: message
     }, req.body.response_url)
 
     return res.status(200).end()

--- a/utils/needs-manual-prs.js
+++ b/utils/needs-manual-prs.js
@@ -22,18 +22,16 @@ async function fetchNeedsManualPRs(branch, prAuthor) {
 }
 
 // Build the text blob that will be posted to Slack
-function buildNeedsManualPRsMessage(branch, prs, initiatedBy) {
-  if (!prs || prs.length === 0) return `*No PRs needing manual backport to ${branch}*`
-
+function buildNeedsManualPRsMessage(branch, prs) {
   const formattedPRs = prs.map(c => {
     return `- ${c.title.split(/[\r\n]/, 1)[0]} (<${c.html_url}|#${c.number}>)`
   }).join('\n')
 
-  let response = `PRs needing manual backport to *${branch}* (from ${initiatedBy}):\n${formattedPRs}`
   if (prs.length !== 0) {
-    response += `\n *There are PRs needing manual backport to \`${branch}\`! Are you sure you want to release?*`
+    formattedPRs += `\n *There are ${prs.length} PRs needing manual backport to \`${branch}\`!*`
   }
-  return response
+
+  return formattedPRs
 }
 
 module.exports = {

--- a/utils/unmerged-prs.js
+++ b/utils/unmerged-prs.js
@@ -17,18 +17,16 @@ async function fetchUnmergedPRs(branch) {
 }
 
 // Build the text blob that will be posted to Slack
-function buildUnmergedPRsMessage(branch, prs, initiatedBy) {
-  if (!prs || prs.length === 0) return `*No unmerged PRs for ${branch}*`
-
+function buildUnmergedPRsMessage(branch, prs) {
   const formattedPRs = prs.map(c => {
     return `- ${c.title.split(/[\r\n]/, 1)[0]} (<${c.html_url}|#${c.number}>)`
   }).join('\n')
 
-  let response = `Unmerged pull requests targeting *${branch}* (from ${initiatedBy}):\n${formattedPRs}`
   if (prs.length !== 0) {
-    response += `\n *There are unmerged PRs targeting \`${branch}\`! Are you sure you want to release?*`
+    formattedPRs += `\n *There are ${prs.length} unmerged PRs targeting \`${branch}\`!*`
   }
-  return response
+
+  return formattedPRs
 }
 
 module.exports = {

--- a/utils/unreleased-commits.js
+++ b/utils/unreleased-commits.js
@@ -24,8 +24,7 @@ async function fetchUnreleasedCommits(branch) {
   return unreleased
 }
 
-// Build the text blob that will be posted to Slack &
-// conditionally notify the release team if it's time to release
+// Build the text blob that will be posted to Slack
 function buildUnreleasedCommitsMessage(branch, commits, initiatedBy) {
   if (!commits || commits.length === 0) return `*No unreleased commits on ${branch}*`
 


### PR DESCRIPTION
This PR refactors the way that messages are put together to reduce redundancies for the new `/audit-pre-release`.