### PR TITLE
feat: add /review-queue for searching for {label}/requested PRs

### DIFF
--- a/utils/issue-search.js
+++ b/utils/issue-search.js
@@ -1,0 +1,27 @@
+const fetch = require('node-fetch');
+const { getAll } = require('./api-helpers')
+
+// Fetch issues matching the given search criteria.
+// e.g.
+// {
+//   repo: 'electron/electron',
+//   type: 'pr',
+//   state: 'open',
+//   label: 'needs-manual-bp/10-x-y'
+// }
+async function searchIssues(search) {
+  const labels = await getAll(`https://api.github.com/repos/${owner}/${repo}/labels`)
+  const baseUrl = `https://api.github.com/search/issues`;
+
+  // Assemble final endpoint.
+  const url = baseUrl + `?q=${[...Object.entries(search)].map(([k, v]) => `${k}:${v}`).map(encodeURIComponent).join('+')}`;
+
+  const resp = await fetch(url);
+  const { items } = await resp.json();
+
+  return items;
+}
+
+module.exports = {
+  searchIssues
+}

--- a/utils/needs-manual-prs.js
+++ b/utils/needs-manual-prs.js
@@ -1,24 +1,19 @@
 const fetch = require('node-fetch');
 const { ORGANIZATION_NAME, REPO_NAME } = require('../constants');
+const { searchIssues } = require('./issue-search');
 
 // Fetch all PRs targeting 'master' that have a 'needs-manual/<branch>' label on them.
 async function fetchNeedsManualPRs(branch, prAuthor) {
-  const baseUrl = `https://api.github.com/search/issues?`;
+  const search = {
+    repo: `${ORGANIZATION_NAME}/${REPO_NAME}`,
+    type: 'pr',
+    state: 'closed',
+    label: `"needs-manual-bp/${branch}"`
+  }
+  if (prAuthor)
+    search.author = prAuthor
 
-  // Construct queryString components.
-  const repo = `repo:${ORGANIZATION_NAME}/${REPO_NAME}`;
-  const type = `type:pr`;
-  const state = `state:closed`;
-  const label = `label:"needs-manual-bp/${branch}"`;
-  const author = prAuthor ? `+author:${prAuthor}` : ``;
-
-  // Assemble final endpoint.
-  const url = baseUrl + `q=${type}+${repo}+${state}+${label}${author}`;
-
-  const resp = await fetch(url);
-  const { items: prs } = await resp.json();
-
-  return prs;
+  return await searchIssues(search)
 }
 
 // Build the text blob that will be posted to Slack.


### PR DESCRIPTION
(includes #21 because I can't work out how to submit a stacked PR without
having access to the repo)

This adds the plumbing for a new /review-queue slash-command endpoint. The
expected usage is e.g. `/review-queue api-review`. That command will search
the configured repo for open prs with the label `api-review/requested 🗳` and
post them to channel.
