### PR TITLE
perf: make the semver check go faster by checking commits in a concurrent queue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2179,6 +2179,14 @@
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
+    "queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "requires": {
+        "inherits": "~2.0.3"
+      }
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "https": "^1.0.0",
     "node-fetch": "^2.6.1",
     "prettier": "^1.19.1",
+    "queue": "^6.0.2",
     "url": "^0.11.0"
   },
   "devDependencies": {

--- a/server.js
+++ b/server.js
@@ -32,6 +32,8 @@ app.use(bodyParser.json());
 app.use(express.static('public'));
 
 app.post('/verify-semver', async (req, res) => {
+  res.status(200).end();
+
   const branches = await getSupportedBranches();
   const branch = req.body.text;
 
@@ -51,7 +53,7 @@ app.post('/verify-semver', async (req, res) => {
       },
       req.body.response_url,
     );
-    return res.status(200).end();
+    return;
   }
 
   try {

--- a/utils/unreleased-commits.js
+++ b/utils/unreleased-commits.js
@@ -14,7 +14,7 @@ async function fetchUnreleasedCommits(branch) {
     `${GH_API_PREFIX}/repos/${ORGANIZATION_NAME}/${REPO_NAME}/tags`,
   );
   const unreleased = [];
-  const url = `${GH_API_PREFIX}/repos/${ORGANIZATION_NAME}/${REPO_NAME}/commits?sha=${branch}`;
+  const url = `${GH_API_PREFIX}/repos/${ORGANIZATION_NAME}/${REPO_NAME}/commits?sha=${branch}&per_page=100`;
 
   for await (const commit of getAllGenerator(url)) {
     const tag = tags.find(t => t.commit.sha === commit.sha);


### PR DESCRIPTION
Makes the verify-semver command run faster by doing the expensive "API request for every commit" step in a concurrent queue instead of sequentially.