### PR TITLE
fix: instead of appending to undef var, init it

### DIFF
--- a/entrypoint.js
+++ b/entrypoint.js
@@ -48,7 +48,7 @@ Toolkit.run(
       if (!prs || prs.length === 0) {
         text = `*No open PRs with label \`${prefix}/requested 🗳\`*`;
       } else {
-        text += `${prs.length} PR${
+        text = `${prs.length} PR${
           prs.length === 1 ? '' : 's'
         } awaiting ${prefix} (from automatic audit):\n`;
         text += buildReviewQueueMessage(prefix, prs);


### PR DESCRIPTION
This fixes a minor bug found by [LGTM](https://lgtm.com/projects/g/electron/unreleased/?mode=list).

```js
let text;
text += 'foo'
```

results in `undefinedfoo`, but what we really wanted was `foo`