### PR TITLE
chore: add error handling for supported branches

### DIFF
--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -101,6 +101,11 @@ async function releaseIsDraft(tag) {
 async function getSupportedBranches() {
   const branchEndpoint = `${GH_API_PREFIX}/repos/${ORGANIZATION_NAME}/${REPO_NAME}/branches?per_page=100`;
   const resp = await fetch(branchEndpoint);
+  if (!resp.ok) {
+    throw new Error(
+      `Error in unreleased when fetching branches: ${resp.statusText}`,
+    );
+  }
 
   let branches = await resp.json();
   const releaseBranches = branches.filter(branch => {


### PR DESCRIPTION
This PR adds more verbose logging for a possible rate-limit error