### PR TITLE
fix: draft is a property on data

### DIFF
--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -82,13 +82,15 @@ async function fetchInitiator(req) {
 // Determine whether a given release is in draft state or not.
 async function releaseIsDraft(tag) {
   try {
-    const { draft } = await octokit.repos.getReleaseByTag({
+    const {
+      data: { draft },
+    } = await octokit.repos.getReleaseByTag({
       owner: ORGANIZATION_NAME,
       repo: REPO_NAME,
       tag,
     });
     return draft;
-  } catch (ignored) {
+  } catch {
     return false;
   }
 }


### PR DESCRIPTION
 Fixes an issue where `isDraft` would always be `undefined`.

This was missed in tests because https://github.com/electron/unreleased/blob/cb036df11a4abdee6493acddb4bbcc712862d3f3/utils/test-gh-apis.js#L36 tests for truthiness, and `undefined` coerced to false, which coincidentally was correct for the test case.