### PR TITLE
chore: decrease number of supported versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ If you would like to use `unreleased`, there are several environment variables y
 
 * `ORGANIZATION_NAME` - the name of your organization, e.g. `electron`.
 * `REPO_NAME` - the name of the repository to run audits in, e.g. `electron`.
-* `NUM_SUPPORTED_VERSIONS` - the number of supported backport release lines (default is 5).
+* `NUM_SUPPORTED_VERSIONS` - the number of supported backport release lines (default is 4).
 * `GITHUB_TOKEN` - the token that will be used to fetch data from the GitHub API (required).
 * `SLACK_BOT_TOKEN` - the token that will be used to post audit result into a Slack workspace channel (required).
 * `BLOCKS_RELEASE_LABEL` - the GitHub label used to denote unmerged pull requests that should block a release (default is `blocks-release`).

--- a/constants.js
+++ b/constants.js
@@ -1,7 +1,7 @@
 const ORGANIZATION_NAME = process.env.ORGANIZATION_NAME || 'electron';
 const REPO_NAME = process.env.REPO_NAME || 'electron';
 
-const NUM_SUPPORTED_VERSIONS = process.env.NUM_SUPPORTED_VERSIONS || 5;
+const NUM_SUPPORTED_VERSIONS = process.env.NUM_SUPPORTED_VERSIONS || 4;
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const SLACK_BOT_TOKEN = process.env.SLACK_BOT_TOKEN;


### PR DESCRIPTION
When we moved our release cadence from 12 weeks to 8 weeks, [we temporarily extended our supported versions from the last three versions to the last four versions](https://www.electronjs.org/blog/8-week-cadence#2021-plan-for-releases). That extension ends next week -  beginning next week, our supported versions will Electron 17, 18 & 19.

This PR bumps the number of supported versions from 5 back to 4.

_NOTE: Please do not merge until after the last 15-x-y and 16-x-y releases have been cut on Tuesday, May 24th_