### PR TITLE
spec: fix failing GH API specs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,4 +24,5 @@ jobs:
     - name: Test GitHub API calls
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        UNRELEASED_GITHUB_APP_CREDS: ${{ secrets.UNRELEASED_GITHUB_APP_CREDS }}
       run: npm run test:ghapi


### PR DESCRIPTION
Fixes failure as seen here: https://github.com/electron/unreleased/actions/runs/3618442124/jobs/6501081452

I've already added `UNRELEASED_GITHUB_APP_CREDS` to repo secrets.