### PR TITLE
build: use node-version with actions/setup-node

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Use Node.js 16.x
+    - name: Use Node.js 18.x
       uses: actions/setup-node@v3
       with:
-        version: 18.x
+        node-version: 18.x
     - name: Lint
       run: |
         npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Use Node.js 18.x
       uses: actions/setup-node@v3
       with:
-        version: 18.x
+        node-version: 18.x
     - name: Test - Unit Tests
       run: |
         npm ci


### PR DESCRIPTION
Support for just `version` was dropped a couple years ago, so the current key has no effect, [see warnings on workflow runs](https://github.com/electron/unreleased/actions/runs/4057415913).