### PR TITLE
test: don't fetch all closed PRs

### DIFF
--- a/test/gh-api-calls.js
+++ b/test/gh-api-calls.js
@@ -25,7 +25,7 @@ describe('API tests', () => {
 
   it('can get the semver value for a commit range', async () => {
     const { commits } = await fetchUnreleasedCommits(branch);
-    const semverType = await getSemverForCommitRange(commits);
+    const semverType = await getSemverForCommitRange(commits, branch);
     const values = ['semver/major', 'semver/minor', 'semver/patch'];
     expect(values).to.contain(semverType);
   });


### PR DESCRIPTION
Looks like this test wasn't using a `branch` for `getSemverForCommitRange` meaning it would fetch all closed PRs on the repo, which is why it was so slow.