### PR TITLE
build: update GitHub actions workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,13 +8,16 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # tag: v3.3.0
     - name: Use Node.js 18.x
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c  # tag: v3.6.0
       with:
         node-version: 18.x
     - name: Lint

--- a/.github/workflows/needs-manual-audit.yml
+++ b/.github/workflows/needs-manual-audit.yml
@@ -9,13 +9,12 @@ jobs:
     name: Perform  Manual Backport Audit
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # tag: v3.3.0
       with:
         ref: main
     - name: Check PRs needing manual backport
       uses: ./
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         UNRELEASED_GITHUB_APP_CREDS: ${{ secrets.UNRELEASED_GITHUB_APP_CREDS }}
         ACTION_TYPE: 'needs-manual'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,13 +8,16 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # tag: v3.3.0
     - name: Use Node.js 18.x
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c  # tag: v3.6.0
       with:
         node-version: 18.x
     - name: Test - Unit Tests
@@ -23,6 +26,5 @@ jobs:
         npm test
     - name: Test - GitHub API calls
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         UNRELEASED_GITHUB_APP_CREDS: ${{ secrets.UNRELEASED_GITHUB_APP_CREDS }}
       run: npm run test:ghapi

--- a/.github/workflows/unreleased-audit.yml
+++ b/.github/workflows/unreleased-audit.yml
@@ -9,13 +9,12 @@ jobs:
     name: Perform Unreleased Audit
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # tag: v3.3.0
       with:
         ref: main
     - name: Check unreleased commits
       uses: ./
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         UNRELEASED_GITHUB_APP_CREDS: ${{ secrets.UNRELEASED_GITHUB_APP_CREDS }}
         ACTION_TYPE: 'unreleased'


### PR DESCRIPTION
* Pins SHAs for actions
* Restricts permissions for lint and test
* Drops `GITHUB_TOKEN` after its usage was removed in 82c72509cbe7de8be3fb4c400be41d3b1b7d49ca