### PR TITLE
build: extend release versions for E22

### DIFF
--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -132,9 +132,15 @@ async function getSupportedBranches() {
     });
 
   const values = Object.values(filtered);
-  return values
+  const supported = values
     .sort((a, b) => parseInt(a, 10) - parseInt(b, 10))
     .slice(-NUM_SUPPORTED_VERSIONS);
+  // TODO: We're supporting Electron 22 until Oct. 10, 2023.
+  // Remove this hardcoded value at that time.
+  if (!supported.includes('22-x-y')) {
+    supported.unshift('22-x-y');
+  }
+  return supported;
 }
 
 // Post a message to a Slack workspace.


### PR DESCRIPTION
Supplemental PR to https://github.com/electron/sudowoodo/pull/241

This PR extends the number of support releases to continue to support Electron 22.

Previously, we've just extended the number of support versions from 3 to 4 (which would also work in this case). However, this will need to be modified after the release of Electron 26 - at that time, the supported versions will be [27-alpha/beta, 26, 25, 24, 22], with 23 missing.