### PR TITLE
build: revert extended release versions for E22

### DIFF
--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -132,15 +132,9 @@ async function getSupportedBranches() {
     });
 
   const values = Object.values(filtered);
-  const supported = values
+  return values
     .sort((a, b) => parseInt(a, 10) - parseInt(b, 10))
     .slice(-NUM_SUPPORTED_VERSIONS);
-  // TODO: We're supporting Electron 22 until Oct. 10, 2023.
-  // Remove this hardcoded value at that time.
-  if (!supported.includes('22-x-y')) {
-    supported.unshift('22-x-y');
-  }
-  return supported;
 }
 
 // Post a message to a Slack workspace.


### PR DESCRIPTION
This PR removes extended support for Electron 22.

Reverts commit 38622d68364445f0665e633824e1447cb5f27f90.