### PR TITLE
refactor: use crypto.timingSafeEqual to check auth header

### DIFF
--- a/server.js
+++ b/server.js
@@ -20,6 +20,7 @@ const {
   isInvalidBranch,
   postToSlack,
   SEMVER_TYPE,
+  timingSafeEqual,
 } = require('./utils/helpers');
 const { getOctokit } = require('./utils/octokit');
 
@@ -30,8 +31,14 @@ app.use(bodyParser.json());
 app.use(express.static('public'));
 
 app.get('/verify-semver', async (req, res) => {
-  if (req.headers.authorization !== process.env.VERIFY_SEMVER_AUTH_HEADER)
+  if (
+    !timingSafeEqual(
+      req.headers.authorization,
+      process.env.VERIFY_SEMVER_AUTH_HEADER,
+    )
+  ) {
     return res.status(401).end();
+  }
 
   const { branch } = req.query;
 
@@ -270,7 +277,12 @@ app.post('/needs-manual', async (req, res) => {
 });
 
 app.get('/unreleased', async (req, res) => {
-  if (req.headers.authorization !== process.env.VERIFY_SEMVER_AUTH_HEADER) {
+  if (
+    !timingSafeEqual(
+      req.headers.authorization,
+      process.env.VERIFY_SEMVER_AUTH_HEADER,
+    )
+  ) {
     return res.status(401).end('Unauthorized');
   }
 

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto');
 const https = require('https');
 const url = require('url');
 const { WebClient } = require('@slack/web-api');
@@ -149,6 +150,17 @@ const postToSlack = (data, postUrl) => {
   r.end(JSON.stringify(data));
 };
 
+function timingSafeEqual(a, b) {
+  const bufferA = Buffer.from(a, 'utf-8');
+  const bufferB = Buffer.from(b, 'utf-8');
+
+  if (bufferA.length !== bufferB.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(bufferA, bufferB);
+}
+
 module.exports = {
   fetchInitiator,
   getSemverForCommitRange,
@@ -158,4 +170,5 @@ module.exports = {
   postToSlack,
   releaseIsDraft,
   SEMVER_TYPE,
+  timingSafeEqual,
 };

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -150,11 +150,17 @@ const postToSlack = (data, postUrl) => {
   r.end(JSON.stringify(data));
 };
 
+// NOTE: This assumes `a` is a user-controlled string and
+// `b` is our sensitive value. This ensures that even in
+// length mismatch cases this function does a
+// crypto.timingSafeEqual comparison of `b.length`, so an
+// attacker can't change `a.length` to estimate `b.length`
 function timingSafeEqual(a, b) {
   const bufferA = Buffer.from(a, 'utf-8');
   const bufferB = Buffer.from(b, 'utf-8');
 
   if (bufferA.length !== bufferB.length) {
+    crypto.timingSafeEqual(bufferB, bufferB);
     return false;
   }
 


### PR DESCRIPTION
Protect against timing attacks.