### PR TITLE
feat: warn if branch has had unreleased commits for N days

### DIFF
--- a/action-audit.js
+++ b/action-audit.js
@@ -15,6 +15,8 @@ const {
   SLACK_BOT_TOKEN,
   ACTION_TYPE,
   AUDIT_POST_CHANNEL,
+  MILLISECONDS_PER_DAY,
+  UNRELEASED_DAYS_WARN_THRESHOLD,
 } = require('./constants');
 
 const Actions = {
@@ -49,6 +51,14 @@ async function run() {
     let text = '';
     if (ACTION_TYPE === Actions.UNRELEASED) {
       text += buildUnreleasedCommitsMessage(branch, commits, initiatedBy);
+      const earliestCommit = commits[0];
+      const unreleasedDays = Math.floor(
+        (Date.now() - new Date(earliestCommit.committer.date).getTime()) /
+          MILLISECONDS_PER_DAY,
+      );
+      if (unreleasedDays > UNRELEASED_DAYS_WARN_THRESHOLD) {
+        text += `\n ⚠️ *There have been unreleased commits on \`${branch}\` for ${unreleasedDays} days!*`;
+      }
     } else if (ACTION_TYPE === Actions.NEEDS_MANUAL) {
       text += buildNeedsManualPRsMessage(
         branch,

--- a/constants.js
+++ b/constants.js
@@ -16,6 +16,10 @@ const RELEASE_BRANCH_PATTERN = /^(\d)+-(?:(?:[0-9]+-x$)|(?:x+-y$))$/;
 
 const BUMP_COMMIT_PATTERN = /Bump v(\d)+.(\d)+.(\d)+(-(beta|nightly)(.\d+))?/;
 
+const MILLISECONDS_PER_DAY = 1000 * 60 * 60 * 24;
+
+const UNRELEASED_DAYS_WARN_THRESHOLD = 8;
+
 module.exports = {
   ACTION_TYPE,
   AUDIT_POST_CHANNEL,
@@ -27,4 +31,6 @@ module.exports = {
   REPO_NAME,
   SLACK_BOT_TOKEN,
   UNRELEASED_GITHUB_APP_CREDS,
+  MILLISECONDS_PER_DAY,
+  UNRELEASED_DAYS_WARN_THRESHOLD,
 };


### PR DESCRIPTION
During an unreleased commits audit, if unreleased commits have been pending for more than `N` days (currently set to 8, happy to tweak) add a warning to the message.