### PR TITLE
fix: handle edge case of no unreleased commits

### DIFF
--- a/action-audit.js
+++ b/action-audit.js
@@ -52,12 +52,14 @@ async function run() {
     if (ACTION_TYPE === Actions.UNRELEASED) {
       text += buildUnreleasedCommitsMessage(branch, commits, initiatedBy);
       const earliestCommit = commits[0];
-      const unreleasedDays = Math.floor(
-        (Date.now() - new Date(earliestCommit.committer.date).getTime()) /
-          MILLISECONDS_PER_DAY,
-      );
-      if (unreleasedDays > UNRELEASED_DAYS_WARN_THRESHOLD) {
-        text += `\n ⚠️ *There have been unreleased commits on \`${branch}\` for ${unreleasedDays} days!*`;
+      if (earliestCommit !== undefined) {
+        const unreleasedDays = Math.floor(
+          (Date.now() - new Date(earliestCommit.committer.date).getTime()) /
+            MILLISECONDS_PER_DAY,
+        );
+        if (unreleasedDays > UNRELEASED_DAYS_WARN_THRESHOLD) {
+          text += `\n ⚠️ *There have been unreleased commits on \`${branch}\` for ${unreleasedDays} days!*`;
+        }
       }
     } else if (ACTION_TYPE === Actions.NEEDS_MANUAL) {
       text += buildNeedsManualPRsMessage(


### PR DESCRIPTION
This wasn't handling the possibility of their being no unreleased commits (and hence no earliest commit), so wrap it in a conditional now.