### PR TITLE
chore: remove papertrail addon from app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,9 +4,7 @@
   "scripts": {},
   "env": {},
   "formation": {},
-  "addons": [
-    "papertrail"
-  ],
+  "addons": [],
   "buildpacks": [
     {
       "url": "heroku/nodejs"


### PR DESCRIPTION
We don't use Papertrail anymore, since everything goes into Datadog.