### PR TITLE
chore: remove BUMP_COMMIT_PATTERN

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -14,8 +14,6 @@ const AUDIT_POST_CHANNEL = process.env.AUDIT_POST_CHANNEL || '#wg-releases';
 
 const RELEASE_BRANCH_PATTERN = /^(\d)+-(?:(?:[0-9]+-x$)|(?:x+-y$))$/;
 
-const BUMP_COMMIT_PATTERN = /Bump v(\d)+.(\d)+.(\d)+(-(beta|nightly)(.\d+))?/;
-
 const MILLISECONDS_PER_DAY = 1000 * 60 * 60 * 24;
 
 const UNRELEASED_DAYS_WARN_THRESHOLD = 8;
@@ -24,7 +22,6 @@ module.exports = {
   ACTION_TYPE,
   AUDIT_POST_CHANNEL,
   BLOCKS_RELEASE_LABEL,
-  BUMP_COMMIT_PATTERN,
   NUM_SUPPORTED_VERSIONS,
   ORGANIZATION_NAME,
   RELEASE_BRANCH_PATTERN,

--- a/utils/unreleased-commits.js
+++ b/utils/unreleased-commits.js
@@ -7,7 +7,6 @@ const {
 } = require('@electron/github-app-auth');
 
 const {
-  BUMP_COMMIT_PATTERN,
   ORGANIZATION_NAME,
   REPO_NAME,
   UNRELEASED_GITHUB_APP_CREDS,
@@ -87,9 +86,6 @@ async function fetchUnreleasedCommits(branch) {
             break;
           }
         }
-
-        // Filter out bump commits.
-        if (BUMP_COMMIT_PATTERN.test(payload.commit.message)) continue;
 
         unreleased.push(payload);
       }


### PR DESCRIPTION
We no longer do bump commits on `e/e` (last one was Oct 2022) so we don't need this since it only reviews commits on supported branches.