### PR TITLE
chore: exclude some commit prefixes from unreleased audit

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -14,6 +14,8 @@ const AUDIT_POST_CHANNEL = process.env.AUDIT_POST_CHANNEL || '#wg-releases';
 
 const RELEASE_BRANCH_PATTERN = /^(\d)+-(?:(?:[0-9]+-x$)|(?:x+-y$))$/;
 
+const EXCLUDED_COMMIT_PATTERN = /^(?:build|ci|test)(?:\(\w+\))?:/;
+
 const MILLISECONDS_PER_DAY = 1000 * 60 * 60 * 24;
 
 const UNRELEASED_DAYS_WARN_THRESHOLD = 8;
@@ -22,6 +24,7 @@ module.exports = {
   ACTION_TYPE,
   AUDIT_POST_CHANNEL,
   BLOCKS_RELEASE_LABEL,
+  EXCLUDED_COMMIT_PATTERN,
   NUM_SUPPORTED_VERSIONS,
   ORGANIZATION_NAME,
   RELEASE_BRANCH_PATTERN,

--- a/test/unreleased-commits.spec.js
+++ b/test/unreleased-commits.spec.js
@@ -5,8 +5,8 @@ const {
   buildUnreleasedCommitsMessage,
 } = require('../utils/unreleased-commits');
 
-describe('unmerged', () => {
-  it('can build the unmerged PRs message', () => {
+describe('unreleased', () => {
+  it('can build the unreleased PRs message', () => {
     const commits = require('./fixtures/unreleased-commits.json');
     const branch = '9-x-y';
     const initiator = 'codebytere';

--- a/utils/unreleased-commits.js
+++ b/utils/unreleased-commits.js
@@ -7,6 +7,7 @@ const {
 } = require('@electron/github-app-auth');
 
 const {
+  EXCLUDED_COMMIT_PATTERN,
   ORGANIZATION_NAME,
   REPO_NAME,
   UNRELEASED_GITHUB_APP_CREDS,
@@ -86,6 +87,9 @@ async function fetchUnreleasedCommits(branch) {
             break;
           }
         }
+
+        // Filter out commits that aren't releasable on their own.
+        if (EXCLUDED_COMMIT_PATTERN.test(payload.commit.message)) continue;
 
         unreleased.push(payload);
       }


### PR DESCRIPTION
Reduces the noise in the unreleased commits audit by excluding commit prefixes (`build:`, `ci:`, and `test:`).