### PR TITLE
chore: run manual backport audit on Mondays

### DIFF
--- a/.github/workflows/needs-manual-audit.yml
+++ b/.github/workflows/needs-manual-audit.yml
@@ -3,7 +3,7 @@ name: Perform Manual Backport Audit
 on:
   workflow_dispatch:
   schedule:
-  - cron: '0 16 * * 3'
+  - cron: '0 16 * * 1'
 
 jobs:
   audit:

--- a/.github/workflows/needs-manual-audit.yml
+++ b/.github/workflows/needs-manual-audit.yml
@@ -3,7 +3,7 @@ name: Perform Manual Backport Audit
 on:
   workflow_dispatch:
   schedule:
-  - cron: '0 16 * * 1'
+  - cron: '0 18 * * 1'
 
 jobs:
   audit:


### PR DESCRIPTION
It's not very useful running on Wednesday since that's when we have automated releases set up.