### PR TITLE
fix: fix warning when we haven't released in N days

### DIFF
--- a/action-audit.js
+++ b/action-audit.js
@@ -51,7 +51,7 @@ async function run() {
     let text = '';
     if (ACTION_TYPE === Actions.UNRELEASED) {
       text += buildUnreleasedCommitsMessage(branch, commits, initiatedBy);
-      const earliestCommit = commits[0];
+      const earliestCommit = commits.at(-1);
       if (earliestCommit !== undefined) {
         const unreleasedDays = Math.floor(
           (Date.now() - new Date(earliestCommit.committer.date).getTime()) /


### PR DESCRIPTION
Commits are returned by the API in reverse chronological order (= newest first).

It was looking at the most recent commit, not the earliest commit.