### PR TITLE
test: try bumping branch version

### DIFF
--- a/test/gh-api-calls.js
+++ b/test/gh-api-calls.js
@@ -15,8 +15,8 @@ const argOptions = {
 
 const { values: argValues } = parseArgs({ options: argOptions });
 
-const branch = argValues?.branch || '17-x-y';
-const tag = argValues?.tag || 'v17.0.0';
+const branch = argValues?.branch || '40-x-y';
+const tag = argValues?.tag || 'v40.0.0';
 const author = argValues?.author || null;
 
 describe('API tests', () => {


### PR DESCRIPTION
Follow-up to #145, which is consistently failing the test job in CI with errors like "GET /repos/electron/electron/commits/d21519ed2e0709169620d75e8969508900e48e84/pulls - 500 with id UNKNOWN"

Trying to bump this test to a newer version to see if that avoids the 500 errors from GitHub which might be related to how old the previous commits were.