### PR TITLE
fix: fetch tags per-branch

### DIFF
--- a/test/gh-api-calls.js
+++ b/test/gh-api-calls.js
@@ -21,8 +21,9 @@ const author = argValues?.author || null;
 
 describe('API tests', () => {
   it('can fetch unreleased commits', async () => {
-    const { commits } = await fetchUnreleasedCommits(branch);
+    const { commits, lastTag } = await fetchUnreleasedCommits(branch);
     assert.ok(Array.isArray(commits));
+    assert.notStrictEqual(lastTag, null);
   });
 
   it('can get the semver value for a commit range', async () => {

--- a/utils/unreleased-commits.js
+++ b/utils/unreleased-commits.js
@@ -8,7 +8,7 @@ const {
   UNRELEASED_GITHUB_APP_CREDS,
 } = require('../constants');
 
-async function fetchTags() {
+async function fetchTags(branch) {
   const { graphql } = await import('@octokit/graphql');
 
   let authorization;
@@ -29,10 +29,14 @@ async function fetchTags() {
     authorization = `token ${process.env.GITHUB_TOKEN}`;
   }
 
+  // Restrict the tag search to the branch's major version (e.g. "v28." for "28-x-y")
+  const major = branch?.match(/^(\d+)-/)?.[1];
+  const tagQuery = major ? `v${major}.` : '';
+
   return graphql({
-    query: `{
+    query: `query($tagQuery: String!) {
       repository(owner: "electron", name: "electron") {
-        refs(refPrefix: "refs/tags/", first: 100, orderBy: { field: TAG_COMMIT_DATE, direction: DESC }) {
+        refs(refPrefix: "refs/tags/", first: 100, query: $tagQuery, orderBy: { field: TAG_COMMIT_DATE, direction: DESC }) {
           edges {
             node {
               name
@@ -44,6 +48,7 @@ async function fetchTags() {
         }
       }
     }`,
+    tagQuery,
     headers: {
       authorization,
     },
@@ -61,7 +66,7 @@ async function fetchTags() {
 
 // Fetch all unreleased commits for a specified release line branch.
 async function fetchUnreleasedCommits(branch) {
-  const tags = await fetchTags();
+  const tags = await fetchTags(branch);
   const unreleased = [];
   let lastTag = null;
 


### PR DESCRIPTION
Tests in CI started failing consistently after #145, paradoxically. Seems like we started exercising a new codepath on GitHub's servers that started giving us 500 errors.

When digging into it, I found that the `fetchTags` call was only returning the last 100 tags on the whole repo, so a call to `fetchUnreleasedCommits` for an older branch might never find a tag for that branch in those 100 and walk all of the commits unnecessarily. Our tests are running against `17-x-y` so they've been hitting this for a while now.

With this fix the CI test job goes from taking multiple minutes to tens of seconds.