### PR TITLE
fix: improve handling of branch validity

### DIFF
--- a/server.js
+++ b/server.js
@@ -15,6 +15,7 @@ const {
 } = require('./utils/needs-manual-prs');
 const {
   fetchInitiator,
+  getReleaseBranches,
   getSemverForCommitRange,
   getSupportedBranches,
   isInvalidBranch,
@@ -42,7 +43,7 @@ app.get('/verify-semver', async (req, res) => {
 
   const { branch } = req.query;
 
-  const branches = await getSupportedBranches();
+  const branches = await getReleaseBranches();
   if (isInvalidBranch(branches, branch)) {
     res.status(400).json({ error: `${branch} is not a valid branch` });
     return;
@@ -69,7 +70,7 @@ app.get('/verify-semver', async (req, res) => {
 app.post('/verify-semver', async (req, res) => {
   res.status(200).end();
 
-  const branches = await getSupportedBranches();
+  const branches = await getReleaseBranches();
   const branch = req.body.text;
 
   const initiator = await fetchInitiator(req);
@@ -120,7 +121,6 @@ app.post('/verify-semver', async (req, res) => {
 // Check for pull requests targeting a specified release branch
 // that have not yet been merged.
 app.post('/unmerged', async (req, res) => {
-  const branches = await getSupportedBranches();
   const branch = req.body.text;
 
   const initiator = await fetchInitiator(req);
@@ -128,7 +128,7 @@ app.post('/unmerged', async (req, res) => {
     `${initiator.name} initiated unmerged audit for branch: ${branch}`,
   );
 
-  if (branch !== 'all' && isInvalidBranch(branches, branch)) {
+  if (branch !== 'all' && isInvalidBranch(await getReleaseBranches(), branch)) {
     console.error(`${branch} is not a valid branch`);
     await postToSlack(
       {
@@ -143,7 +143,8 @@ app.post('/unmerged', async (req, res) => {
   console.log(`Auditing unmerged PRs on branch: ${branch}`);
 
   try {
-    const branchesToCheck = branch === 'all' ? branches : [branch];
+    const branchesToCheck =
+      branch === 'all' ? await getSupportedBranches() : [branch];
 
     let messages = [];
     for (const branch of branchesToCheck) {
@@ -184,7 +185,6 @@ app.post('/unmerged', async (req, res) => {
 // Check for pull requests which have been merged to main and labeled
 // with target/BRANCH_NAME that trop failed for and which still need manual backports.
 app.post('/needs-manual', async (req, res) => {
-  const branches = await getSupportedBranches();
   const REMIND = 'remind';
 
   let [branch, author, remind] = req.body.text.split(' ');
@@ -202,7 +202,7 @@ app.post('/needs-manual', async (req, res) => {
     `${initiator.name} initiated needs-manual audit for branch: ${branch}`,
   );
 
-  if (branch !== 'all' && isInvalidBranch(branches, branch)) {
+  if (branch !== 'all' && isInvalidBranch(await getReleaseBranches(), branch)) {
     console.error(`${branch} is not a valid branch`);
     await postToSlack(
       {
@@ -234,7 +234,8 @@ app.post('/needs-manual', async (req, res) => {
   }
 
   try {
-    const branchesToCheck = branch === 'all' ? branches : [branch];
+    const branchesToCheck =
+      branch === 'all' ? await getSupportedBranches() : [branch];
 
     let messages = [];
     for (const branch of branchesToCheck) {
@@ -289,15 +290,16 @@ app.get('/unreleased', async (req, res) => {
   const { branch } = req.query;
 
   try {
-    const branches = await getSupportedBranches();
     const result = {};
 
     if (branch === 'all') {
+      const branches = await getSupportedBranches();
       for (const b of branches) {
         const { commits } = await fetchUnreleasedCommits(b);
         result[b] = commits;
       }
     } else {
+      const branches = await getReleaseBranches();
       if (isInvalidBranch(branches, branch)) {
         return res
           .status(400)
@@ -319,13 +321,13 @@ app.get('/unreleased', async (req, res) => {
 // Check for commits which have been merged to a release branch but
 // not been released in a beta or stable.
 app.post('/unreleased', async (req, res) => {
-  const branches = await getSupportedBranches();
   const branch = req.body.text;
 
   const initiator = await fetchInitiator(req);
 
   // Allow for manual batch audit of all supported release branches.
   if (branch === 'all') {
+    const branches = await getSupportedBranches();
     console.log(
       `${initiator.name} triggered audit for all supported release branches`,
     );
@@ -360,6 +362,8 @@ app.post('/unreleased', async (req, res) => {
   console.log(
     `${initiator.name} initiated unreleased commit audit for branch: ${branch}`,
   );
+
+  const branches = await getReleaseBranches();
 
   if (isInvalidBranch(branches, branch)) {
     console.error(`${branch} is not a valid branch`);
@@ -401,7 +405,7 @@ app.post('/unreleased', async (req, res) => {
 // Combines checks for all PRs that either need manual backport to a given
 // release line or which are targeting said line and haven't been merged.
 app.post('/audit-pre-release', async (req, res) => {
-  const branches = await getSupportedBranches();
+  const branches = await getReleaseBranches();
   const branch = req.body.text;
 
   const initiator = await fetchInitiator(req);

--- a/test/gh-api-calls.js
+++ b/test/gh-api-calls.js
@@ -4,6 +4,7 @@ const { parseArgs } = require('node:util');
 
 const { fetchUnreleasedCommits } = require('../utils/unreleased-commits');
 const {
+  getReleaseBranches,
   getSemverForCommitRange,
   getSupportedBranches,
   releaseIsDraft,
@@ -50,6 +51,18 @@ describe('API tests', () => {
   it('can fetch PRs needing merge', async () => {
     const prs = await fetchUnmergedPRs(branch);
     assert.ok(Array.isArray(prs));
+  });
+
+  it('can get release branches', async () => {
+    const branches = await getReleaseBranches();
+    assert.ok(Array.isArray(branches));
+    assert.strictEqual(branches.length, 10);
+  });
+
+  it('can get more release branches', async () => {
+    const branches = await getReleaseBranches(15);
+    assert.ok(Array.isArray(branches));
+    assert.strictEqual(branches.length, 15);
   });
 
   it('can get supported branches', async () => {

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -107,19 +107,29 @@ async function releaseIsDraft(tag) {
   }
 }
 
-// Fetch an array of the currently supported branches.
-async function getSupportedBranches() {
+async function fetchSchedule() {
   const resp = await fetch('https://releases.electronjs.org/schedule.json');
   if (!resp.ok) {
     throw new Error(
-      `Failed to fetch supported branches: ${resp.status} ${resp.statusText}`,
+      `Failed to fetch release branches: ${resp.status} ${resp.statusText}`,
     );
   }
   const schedule = await resp.json();
+  return Object.values(schedule);
+}
 
-  return Object.values(schedule)
+// Fetch an array of the currently supported branches.
+async function getSupportedBranches() {
+  const schedule = await fetchSchedule();
+  return schedule
     .filter(({ status }) => ['prerelease', 'stable'].includes(status))
     .map(({ branch }) => branch);
+}
+
+// Fetch an array of newest N release branches
+async function getReleaseBranches(n = 10) {
+  const schedule = await fetchSchedule();
+  return schedule.slice(0, n).map(({ branch }) => branch);
 }
 
 // Post a message to a Slack workspace.
@@ -152,6 +162,7 @@ function timingSafeEqual(a, b) {
 
 module.exports = {
   fetchInitiator,
+  getReleaseBranches,
   getSemverForCommitRange,
   getSupportedBranches,
   isInvalidBranch,

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -118,18 +118,67 @@ async function fetchSchedule() {
   return Object.values(schedule);
 }
 
+async function branchExists(branch) {
+  const octokit = await getOctokit();
+
+  try {
+    await octokit.rest.repos.getBranch({
+      owner: ORGANIZATION_NAME,
+      repo: REPO_NAME,
+      branch,
+    });
+  } catch (err) {
+    // A 404 means the branch genuinely doesn't exist
+    if (err.status === 404) {
+      return false;
+    }
+    throw err;
+  }
+
+  return true;
+}
+
+async function checkForNewReleaseBranch(latestVersion) {
+  const latestMajor = latestVersion.split('.')[0];
+  const nextMajorBranch = `${latestMajor}-x-y`;
+
+  if (await branchExists(nextMajorBranch)) {
+    return nextMajorBranch;
+  }
+
+  return null;
+}
+
 // Fetch an array of the currently supported branches.
 async function getSupportedBranches() {
   const schedule = await fetchSchedule();
-  return schedule
+  const branches = schedule
     .filter(({ status }) => ['prerelease', 'stable'].includes(status))
     .map(({ branch }) => branch);
+
+  // Schedule is cached, so check GH for a new release branch
+  const newReleaseBranch = await checkForNewReleaseBranch(schedule[0].version);
+  if (newReleaseBranch) {
+    branches.unshift(newReleaseBranch);
+    branches.pop(); // Knock out the last stable branch if we have a new release branch
+  }
+
+  return branches;
 }
 
 // Fetch an array of newest N release branches
 async function getReleaseBranches(n = 10) {
   const schedule = await fetchSchedule();
-  return schedule.slice(0, n).map(({ branch }) => branch);
+  const branches = schedule.slice(0, n).map(({ branch }) => branch);
+
+  // Schedule is cached, so check GH for a new release branch
+  const newReleaseBranch = await checkForNewReleaseBranch(schedule[0].version);
+  if (newReleaseBranch) {
+    branches.splice(1, 0, newReleaseBranch);
+    branches.pop();
+  }
+
+  return branches;
 }
 
 // Post a message to a Slack workspace.

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -109,9 +109,7 @@ async function releaseIsDraft(tag) {
 
 // Fetch an array of the currently supported branches.
 async function getSupportedBranches() {
-  const resp = await fetch(
-    'https://releases.electronjs.org/schedule.json?eolGracePeriod=7',
-  );
+  const resp = await fetch('https://releases.electronjs.org/schedule.json');
   if (!resp.ok) {
     throw new Error(
       `Failed to fetch supported branches: ${resp.status} ${resp.statusText}`,


### PR DESCRIPTION
This contains a few different changes:
* Reverts #156 as this solves the underlying problem of running `/verify-semver` on an EOL branch
* Allows EOL branches to be used in all commands if they're specifically named - providing 'all' for the branch name still distills down to just supported branches
* Always checks for the latest potential major branch on GH since `/schedule.json` is cached - this closes the window where a new release branch has just been cut and the schedule hasn't reflected it yet