### PR TITLE
build(deps): drop body-parser as direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "@electron/github-app-auth": "^3.0.0",
     "@octokit/rest": "^22.0.0",
     "@slack/web-api": "^6.10.0",
-    "body-parser": "^2.2.1",
     "express": "^5.0.1"
   },
   "devDependencies": {

--- a/server.js
+++ b/server.js
@@ -1,5 +1,4 @@
 const express = require('express');
-const bodyParser = require('body-parser');
 
 const {
   buildUnreleasedCommitsMessage,
@@ -25,8 +24,8 @@ const {
 const { getOctokit } = require('./utils/octokit');
 
 const app = express();
-app.use(bodyParser.urlencoded({ extended: true }));
-app.use(bodyParser.json());
+app.use(express.urlencoded({ extended: true }));
+app.use(express.json());
 
 app.use(express.static('public'));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -565,7 +565,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"body-parser@npm:^2.2.0, body-parser@npm:^2.2.1":
+"body-parser@npm:^2.2.0":
   version: 2.2.2
   resolution: "body-parser@npm:2.2.2"
   dependencies:
@@ -2240,7 +2240,6 @@ __metadata:
     "@octokit/graphql": "npm:^9.0.0"
     "@octokit/rest": "npm:^22.0.0"
     "@slack/web-api": "npm:^6.10.0"
-    body-parser: "npm:^2.2.1"
     eslint: "npm:^9.12.0"
     express: "npm:^5.0.1"
     globals: "npm:^15.11.0"


### PR DESCRIPTION
Express 5 has a dependency on `body-parser` and exposes the same parsers directly from the `express` package, so drop the direct dependency and use them via `express`.